### PR TITLE
Revert "Use gorilla/context to handle context"

### DIFF
--- a/hapi_Register_test.go
+++ b/hapi_Register_test.go
@@ -1,29 +1,25 @@
 package hapi
 
 import (
-    "net/http"
     "testing"
-
-    "github.com/gorilla/context"
-    "github.com/julienschmidt/httprouter"   /* HTTP router */
+//     "net/http"
 )
 
 func (h *HypermediaAPI) DoRegisterTest(name, requestedType, expectedType, expectedID string, t *testing.T) {
-    negType,typeHandler := h.TypeAndHandler("GET","/",requestedType)
+    negType,negHandler := h.TypeAndHandler("GET","/",requestedType)
     if negType != expectedType {
         t.Fatalf("%s: TypeAndHandler returned '%s', expected '%s'\n", name, negType, expectedType)
     }
-    w := new(mockResponseWriter)
-    r,_ := http.NewRequest("GET","/",nil)
-
-    if typeHandler != nil {
-        typeHandler( w, r )
+    context := &Context{}
+    context.Stash = make(map[string]interface{})
+    if negHandler != nil {
+        negHandler( context )
     }
-    if id,ok := context.GetOk(r,"id"); ! ok {
-        if ( len(expectedID) > 0 ) {
-            t.Fatalf("%s: Error reading id after request\n", name)
-        }
-    } else if id != expectedID {
+    var id string
+    if context.Stash["id"] != nil {
+        id = context.Stash["id"].(string)
+    }
+    if id != expectedID {
         t.Fatalf("%s: Handler identified itself as '%s', expected '%s'\n", name, id, expectedID)
     }
 }
@@ -35,25 +31,4 @@ func TestRegister1(t *testing.T) {
     router.DoRegisterTest("text/html 2","text/*","text/html","1",t)
     router.DoRegisterTest("text/html 3","*/*","text/html","1",t)
     router.DoRegisterTest("text/html 4","text/plain","","",t)
-}
-
-func TestHandle(t *testing.T) {
-    var negotiatedType string
-    var foo string
-    handler := func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
-        negotiatedType = context.Get(r,"Content-Type").(string)
-        foo = p.ByName("foo")
-    }
-    
-    router := New()
-    router.Handle("GET","/:foo","text/html",handler)
-    w := new(mockResponseWriter)
-    r,_ := http.NewRequest("GET","/bar",nil)
-    router.ServeHTTP(w,r)
-    if negotiatedType != "text/html" {
-        t.Fatalf("httprouter.Handle set Content-Type to '%s', expected 'text/html'. httprouter context not working.\n", negotiatedType)
-    }
-    if foo != "bar" {
-        t.Fatalf("httprouter.Handle set foo to '%s', expected 'bar'. httprouter.Params handling not working.\n", foo)
-    }
 }

--- a/hapi_Routing_test.go
+++ b/hapi_Routing_test.go
@@ -3,26 +3,36 @@ package hapi
 import (
     "testing"
     "net/http"
-
 //     "github.com/julienschmidt/httprouter"
 )
+
+type mockResponseWriter struct{}
+
+func (m *mockResponseWriter) Header() (h http.Header) {
+    return http.Header{}
+}
+
+func (m *mockResponseWriter) Write(p []byte) (n int, err error) {
+    return len(p), nil
+}
+
+func (m *mockResponseWriter) WriteString(s string) (n int, err error) {
+    return len(s), nil
+}
+
+func (m *mockResponseWriter) WriteHeader(int) {}
 
 func TestRouting(t *testing.T) {
     router := New()
     handlerID := ""
-    router.Register("GET","/","text/html", func (_ http.ResponseWriter, _ *http.Request) { handlerID = "1" })
-    router.UnsupportedMediaType = func (_ http.ResponseWriter, _ *http.Request) { handlerID = "unsupported" }
+    router.Register("GET","/","text/html", func (c *Context) { handlerID = "1" })
+    router.UnsupportedMediaType = func (c *Context) { handlerID = "unsupported" }
     w := new(mockResponseWriter)
     req,_ := http.NewRequest("GET","/",nil)
-    router.ServeHTTP(w,req)
-    if handlerID != "1" {
-        t.Fatal("Routing failed with no Accept: header")
-    }
-
     req.Header.Set("Accept","text/html")
     router.ServeHTTP(w,req)
     if handlerID != "1" {
-        t.Fatal("Routing failed for explicit Accept: header")
+        t.Fatal("routing failed")
     }
 
     req.Header.Set("Accept","text/plain")

--- a/hapi_test.go
+++ b/hapi_test.go
@@ -1,28 +1,6 @@
 package hapi
 
-import (
-    "net/http"
-
-    "github.com/gorilla/context"
-)
-
 // A common function for various test cases
 func (h *HypermediaAPI) TestRegister(ctype,id string) {
-    h.Register("GET", "/", ctype, func(w http.ResponseWriter, r *http.Request) { context.Set(r,"id",id) })
+    h.Register("GET", "/", ctype, func(c *Context) { c.Stash["id"] = id })
 }
-
-type mockResponseWriter struct{}
-
-func (m *mockResponseWriter) Header() (h http.Header) {
-    return http.Header{}
-}
-
-func (m *mockResponseWriter) Write(p []byte) (n int, err error) {
-    return len(p), nil
-}
-
-func (m *mockResponseWriter) WriteString(s string) (n int, err error) {
-    return len(s), nil
-}
-
-func (m *mockResponseWriter) WriteHeader(int) {}


### PR DESCRIPTION
Reverts flimzy/hapi#1

After much consideration and reading, I have decided that passing a generic context variable in is a better, more scalable approach.
